### PR TITLE
Fix domain_enabled boolean comparison in dialplan XML handler

### DIFF
--- a/app/switch/resources/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
+++ b/app/switch/resources/scripts/app/xml_handler/resources/scripts/dialplan/dialplan.lua
@@ -198,7 +198,7 @@
 					else
 						xml:append(row.dialplan_xml);
 					end
-					if (row.domain_enabled == true) then
+					if (row.domain_enabled == true or row.domain_enabled == "true" or row.domain_enabled == "t") then
 						xml:append(row.dialplan_xml);
 					end
 				end);


### PR DESCRIPTION
## Summary
- Fix inbound call routing failure caused by `domain_enabled` boolean comparison in the Lua dialplan XML handler

## Problem
In `dialplan.lua`, the inbound destination lookup query returns `domain_enabled` from the `v_domains` PostgreSQL table. The code checks `row.domain_enabled == true` (Lua boolean), but depending on the Lua PostgreSQL driver, the value may be returned as the string `"true"` or `"t"` rather than a Lua boolean. When this happens, the comparison silently fails and the destination's dialplan XML is never appended to the response, causing all inbound calls to hit the `not-found` fallback (404).

## Fix
Accept all possible representations of a PostgreSQL boolean true: Lua boolean `true`, string `"true"`, and string `"t"`.

## Test plan
- [x] Verified on a fresh FS PBX 1.6.1 install with PostgreSQL — inbound calls to a DID with a domain-scoped destination were returning 404 before the fix
- [x] After the fix, inbound calls correctly route through the destination's dialplan (IVR, ring groups, etc.)